### PR TITLE
Added Meta Engine support

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,33 @@ Creating a search key that will only search over the body field.
 >>> client = Client(host_identifier, signed_search_key)
 ```
 
+### Create a Meta Engine
+
+```python
+>>> client.create_engine('my-meta-engine', options={
+  'type': 'meta',
+  'source_engines': [
+    'source-engine-1',
+    'source-engine-2'
+  ]
+})
+{'source_engines': ['source-engine-1', 'source-engine-2'], 'type': 'meta', 'name': 'my-meta-engine'}
+```
+
+### Add a Source Engine to a Meta Engine
+
+```python
+>>> client.add_source_engines('my-meta-engine', ['source-engine-3'])
+{'source_engines': ['source-engine-1', 'source-engine-2', 'source-engine-3'], 'type': 'meta', 'name': 'my-meta-engine'}
+```
+
+### Remove a Source Engine from a Meta Engine
+
+```python
+>>> client.remove_source_engines('my-meta-engine', ['source-engine-3'])
+{'source_engines': ['source-engine-1', 'source-engine-2'], 'type': 'meta', 'name': 'my-meta-engine'}
+```
+
 ## Running tests
 
 ```python

--- a/elastic_app_search/client.py
+++ b/elastic_app_search/client.py
@@ -149,16 +149,19 @@ class Client:
         """
         return self.session.request('get', "engines/{}".format(engine_name))
 
-    def create_engine(self, engine_name, language=None):
+    def create_engine(self, engine_name, language=None, options=None):
         """
         Creates an engine with the specified name.
         :param engine_name: Name of the new engine.
         :param language: Language of the new engine.
+        :param options: Engine configuration.
         :return: A dictionary corresponding to the new engine.
         """
         data = { 'name': engine_name }
         if language is not None:
             data['language'] = language
+        if options is not None:
+            data.update(options)
         return self.session.request('post', 'engines', json=data)
 
     def destroy_engine(self, engine_name):
@@ -289,6 +292,13 @@ class Client:
         endpoint = "engines/{}/click".format(engine_name)
         return self.session.request_ignore_response('post', endpoint, json=options)
 
+    def add_source_engines(self, engine_name, source_engines):
+        endpoint = "engines/{}/source_engines".format(engine_name)
+        return self.session.request('post', endpoint, json=source_engines)
+
+    def remove_source_engines(self, engine_name, source_engines):
+        endpoint = "engines/{}/source_engines".format(engine_name)
+        return self.session.request('delete', endpoint, json=source_engines)
 
     @staticmethod
     def create_signed_search_key(api_key, api_key_name, options):

--- a/elastic_app_search/exceptions.py
+++ b/elastic_app_search/exceptions.py
@@ -15,6 +15,9 @@ class RecordAlreadyExists(ElasticAppSearchError):
 class BadRequest(ElasticAppSearchError):
     """Raised when bad request"""
 
+    def __init__(self, message):
+        super(ElasticAppSearchError, self).__init__(message)
+
 class Forbidden(ElasticAppSearchError):
     """Raised when http forbidden"""
 

--- a/elastic_app_search/request_session.py
+++ b/elastic_app_search/request_session.py
@@ -22,7 +22,7 @@ class RequestSession:
         if response.status_code == requests.codes.unauthorized:
             raise InvalidCredentials(response.reason)
         elif response.status_code == requests.codes.bad:
-            raise BadRequest()
+            raise BadRequest(response.text)
         elif response.status_code == requests.codes.conflict:
             raise RecordAlreadyExists()
         elif response.status_code == requests.codes.not_found:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -253,7 +253,29 @@ class TestClient(TestCase):
         with requests_mock.Mocker() as m:
             url = "{}/{}".format(self.client.session.base_url, 'engines')
             m.register_uri('POST', url, json=expected_return, status_code=200)
-            response = self.client.create_engine(engine_name, 'en')
+            response = self.client.create_engine(
+                engine_name=engine_name, language='en')
+            self.assertEqual(response, expected_return)
+
+    def test_create_engine_with_options(self):
+        engine_name = 'myawesomeengine'
+        expected_return = {'name': engine_name, 'type': 'meta',
+                           'source_engines': [
+                               'source-engine-1',
+                               'source-engine-2'
+                           ]}
+
+        with requests_mock.Mocker() as m:
+            url = "{}/{}".format(self.client.session.base_url, 'engines')
+            m.register_uri('POST', url, json=expected_return, status_code=200)
+            response = self.client.create_engine(
+                engine_name=engine_name, options={
+                    'type': 'meta',
+                    'source_engines': [
+                        'source-engine-1',
+                        'source-engine-2'
+                    ]
+                })
             self.assertEqual(response, expected_return)
 
     def test_destroy_engine(self):
@@ -487,3 +509,34 @@ class TestClient(TestCase):
             m.register_uri('POST', url, json={}, status_code=200)
             self.client.click(self.engine_name, {
                               'query': 'cat', 'document_id': 'INscMGmhmX4'})
+
+    def test_add_source_engines(self):
+        target_source_engine_name = 'source-engine-3'
+        expected_return = {'source_engines': [
+            'source-engine-1', 'source-engine-2', target_source_engine_name], 'type': 'meta', 'name': self.engine_name}
+
+        with requests_mock.Mocker() as m:
+            url = "{}/{}".format(
+                self.client.session.base_url,
+                "engines/{}/source_engines".format(self.engine_name)
+            )
+            m.register_uri('POST', url, json=expected_return, status_code=200)
+            response = self.client.add_source_engines(
+                self.engine_name, [target_source_engine_name])
+            self.assertEqual(response, expected_return)
+
+    def test_remove_source_engines(self):
+        source_engine_name = 'source-engine-3'
+        expected_return = {'source_engines': [
+            'source-engine-1', 'source-engine-2'], 'type': 'meta', 'name': self.engine_name}
+
+        with requests_mock.Mocker() as m:
+            url = "{}/{}".format(
+                self.client.session.base_url,
+                "engines/{}/source_engines".format(self.engine_name)
+            )
+            m.register_uri('DELETE', url, json=expected_return,
+                           status_code=200)
+            response = self.client.remove_source_engines(
+                self.engine_name, [source_engine_name])
+            self.assertEqual(response, expected_return)


### PR DESCRIPTION
This PR adds support for the 2 new endpoints being introduced for Meta Engines:
- add_source_engines
- remove_source_engines

Additionally, in order to support the creation of meta engines, the `create_engine` method needed to be updated in order to support an `options` object.

I also added the response text to `BadRequest` exceptions, because they previously gave no description of what was wrong with the request, which left the user unable to resolve the errors. They now appear as:

```
elastic_app_search.exceptions.BadRequest: {"errors":["Name can only contain lowercase letters, numbers, and hyphens"]}
```